### PR TITLE
Ignore saving cache errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,17 @@ jobs:
           else
             echo "Tarantool version is $T, as expected"
           fi
+
+  test-concurrency:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-20.04, ubuntu-20.04, ubuntu-20.04]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Tarantool
+        uses: ./
+        with:
+          tarantool-version: '1.10'
+          cache-key: test-concurrency-${{ github.run_id }}

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -3472,8 +3472,14 @@ async function run_linux() {
                 await io.cp(f, dest);
             }
         }
-        await cache.saveCache([cache_dir], cache_key);
-        core.info(`Cache saved with key: ${cache_key}`);
+        try {
+            await cache.saveCache([cache_dir], cache_key);
+            core.info(`Cache saved with key: ${cache_key}`);
+        }
+        catch (error) {
+            core.warning(error.message);
+            core.warning(`Saving cache failed, but it's not crucial`);
+        }
         await io.rmRF(cache_dir);
     }
     catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,8 +107,14 @@ async function run_linux(): Promise<void> {
       }
     }
 
-    await cache.saveCache([cache_dir], cache_key)
-    core.info(`Cache saved with key: ${cache_key}`)
+    try {
+      await cache.saveCache([cache_dir], cache_key)
+      core.info(`Cache saved with key: ${cache_key}`)
+    } catch (error) {
+      core.warning(error.message)
+      core.warning(`Saving cache failed, but it's not crucial`)
+    }
+
     await io.rmRF(cache_dir)
   } catch (error) {
     core.setFailed(error.message)


### PR DESCRIPTION
Parallel jobs sometimes fail with an error: "Unable to reserve cache with key ..., another job may be creating this cache.":

![image](https://user-images.githubusercontent.com/2205188/102815371-4dfa1300-43dd-11eb-9ba2-758ec59726ab.png)

This patch makes it just a warning:

![image](https://user-images.githubusercontent.com/2205188/102815421-61a57980-43dd-11eb-9102-d5c4dd92494c.png)
